### PR TITLE
Multi-Server Update

### DIFF
--- a/onlmonclient/OnlMonClient.cc
+++ b/onlmonclient/OnlMonClient.cc
@@ -6,7 +6,6 @@
 #include <onlmon/HistoBinDefs.h>
 #include <onlmon/OnlMonBase.h>  // for OnlMonBase
 #include <onlmon/OnlMonDefs.h>
-#include <onlmon/OnlMonTrigger.h>
 
 #include <MessageTypes.h>  // for kMESS_STRING, kMESS_OBJECT
 #include <TCanvas.h>
@@ -67,7 +66,6 @@ OnlMonClient::OnlMonClient(const std::string &name)
 {
   defaultStyle = new TStyle();
   SetStyleToDefault();
-  onltrig = new OnlMonTrigger();
   InitAll();
 }
 
@@ -143,7 +141,6 @@ OnlMonClient::~OnlMonClient()
   }
   delete clientrunning;
   delete fHtml;
-  delete onltrig;
   delete defaultStyle;
   // this deletes all open canvases
   TSeqCollection *allCanvases = gROOT->GetListOfCanvases();
@@ -408,7 +405,6 @@ int OnlMonClient::requestHistoBySubSystem(const std::string &subsys, int getall)
     }
   }
   m_LastMonitorFetched = subsys;
-  onltrig->RunNumber(RunNumber());
   return iret;
 }
 
@@ -1232,7 +1228,6 @@ int OnlMonClient::ReadHistogramsFromFile(const char *filename)
   }
   delete histofile;
   delete titer;
-  onltrig->RunNumber(RunNumber());
   return 0;
 }
 
@@ -1384,15 +1379,6 @@ int OnlMonClient::HistoToPng(TH1 *histo, std::string const &pngfilename, const c
   return 0;
 }
 
-OnlMonTrigger *
-OnlMonClient::OnlTrig()
-{
-  if (!onltrig)
-  {
-    onltrig = new OnlMonTrigger();
-  }
-  return onltrig;
-}
 
 int OnlMonClient::SaveLogFile(const OnlMonDraw &drawer)
 {

--- a/onlmonclient/OnlMonClient.h
+++ b/onlmonclient/OnlMonClient.h
@@ -13,7 +13,6 @@
 class ClientHistoList;
 class OnlMonDraw;
 class OnlMonHtml;
-class OnlMonTrigger;
 class TCanvas;
 class TH1;
 class TStyle;
@@ -68,8 +67,6 @@ class OnlMonClient : public OnlMonBase
   int HistoToPng(TH1 *histo, std::string const &pngfilename, const char *drawopt = "", const int statopt = 11);
 
   int SaveLogFile(const OnlMonDraw &drawer);
-  // interface to OnlMonTrigger class methods
-  OnlMonTrigger *OnlTrig();
   using OnlMonBase::Verbosity;
   void Verbosity(const int i) override;
   int SetStyleToDefault();
@@ -88,7 +85,6 @@ class OnlMonClient : public OnlMonBase
 
   static OnlMonClient *__instance;
   OnlMonHtml *fHtml = nullptr;
-  OnlMonTrigger *onltrig = nullptr;
   TH1 *clientrunning = nullptr;
   TStyle *defaultStyle = nullptr;
 


### PR DESCRIPTION
At long last

Big updates
- Drawing macro now pulls histos from multiple SEB's, this was why it was only showing a sliver of the detector at once
- Also fixed mismatch between client and drawing code so that the right histos are being grabbed, this caused the segfault that caused the windows to collapse

Small update
- Changed window on pedestal distribution
- Offset fast vs. template time diff histo by six to center it at zero (it'll always peak at six, might as well make it the new zero)
- Removed some requests for expert calls based on hit map thresholds, we're not ready for those calls yet. 